### PR TITLE
Request limiting and access tokens

### DIFF
--- a/SpaceDock-Backend.pyproj
+++ b/SpaceDock-Backend.pyproj
@@ -57,6 +57,9 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="SpaceDock\endpoints\publisher.py" />
+    <Compile Include="SpaceDock\endpoints\tokens.py">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="SpaceDock\endpoints\user.py" />
     <Compile Include="SpaceDock\endpoints\__init__.py" />
     <Compile Include="SpaceDock\plugins.py">

--- a/SpaceDock/common.py
+++ b/SpaceDock/common.py
@@ -2,7 +2,6 @@ from flask import make_response, request
 from flask_json import as_json, as_json_p
 from flask_login import current_user
 from functools import wraps
-from SpaceDock.app import limiter
 from SpaceDock.config import cfg
 from SpaceDock.database import db
 from SpaceDock.objects import Ability, Game, Token
@@ -163,7 +162,7 @@ def re_in(itr, value):
     if value == None:
         return False
     for v in itr:
-        if not re.match(str(v), value) == None:
+        if not re.match(str(v), str(value)) == None:
             return True
     return False
 
@@ -213,6 +212,7 @@ def limit(f):
     """
     Limits the amount of requests a user can make
     """
+    from SpaceDock.app import limiter
     def exceptions():
         """
         Checks if a user shouldn't be limited
@@ -221,7 +221,6 @@ def limit(f):
             return True
         if 'token' in request.args:
             s_token = request.args.get('token')
-            del request.args['token']
             token = Token.query.filter(Token.token == s_token).first()
             if not token:
                 return False

--- a/SpaceDock/common.py
+++ b/SpaceDock/common.py
@@ -219,9 +219,9 @@ def limit(f):
         """
         if current_user and has_ability('no-limits'):
             return True
-        if 'token' in request.json:
-            s_token = request.json.get('token')
-            del request.json['token']
+        if 'token' in request.args:
+            s_token = request.args.get('token')
+            del request.args['token']
             token = Token.query.filter(Token.token == s_token).first()
             if not token:
                 return False

--- a/SpaceDock/endpoints/tokens.py
+++ b/SpaceDock/endpoints/tokens.py
@@ -14,6 +14,8 @@ def generate_token():
     """
     token = Token()
     db.add(token)
+    db.flush()
+    token['ips'] = list()
     return {'error': False, 'count': 1, 'data': token_format(token)}
 
 @route('/api/tokens/edit', methods=['POST'])

--- a/SpaceDock/endpoints/tokens.py
+++ b/SpaceDock/endpoints/tokens.py
@@ -1,0 +1,54 @@
+from flask import request
+from SpaceDock.common import user_has, with_session
+from SpaceDock.database import db
+from SpaceDock.formatting import token_format
+from SpaceDock.objects import Token
+from SpaceDock.routing import route
+
+@route('/api/tokens/generate', methods=['POST'])
+@user_has('token-generate')
+@with_session
+def generate_token():
+    """
+    Generates a new API token
+    """
+    token = Token()
+    db.add(token)
+    return {'error': False, 'count': 1, 'data': token_format(token)}
+
+@route('/api/tokens/edit', methods=['POST'])
+@user_has('token-edit', params=['tokenid'])
+@with_session
+def edit_token():
+    """
+    Edits the IP-Adresses of a token
+    """
+    tokenid = request.json.get('tokenid')
+    ips = request.json.get('ips')
+
+    # Check for int
+    if not isinstance(tokenid, int) or not Token.query.filter(Token.id == tokenid).first():
+        return {'error': True, 'reasons': ['The token ID is invalid'], 'codes': ['2131']}, 400
+    if not ips or not isinstance(ips, list):
+        return {'error': True, 'reasons': ['The list of IP Addresses is invalid.'], 'codes': ['2132']}, 400
+    token = Token.query.filter(Token.id == tokenid).first()
+
+    # Edit the token
+    token['ips'] = ips
+    return {'error': False, 'count': 1, 'data': token_format(token)}
+
+@route('/api/tokens/revoke', methods=['POST'])
+@user_has('token-revoke', params=['tokenid'])
+@with_session
+def revoke_token():
+    """
+    Removes a token completely
+    """
+    tokenid = request.json.get('tokenid')
+
+    # Check for int
+    if not isinstance(tokenid, int) or not Token.query.filter(Token.id == tokenid).first():
+        return {'error': True, 'reasons': ['The token ID is invalid'], 'codes': ['2131']}, 400
+    token = Token.query.filter(Token.id == tokenid).first()
+    db.delete(token)
+    return {'error': False}

--- a/SpaceDock/formatting.py
+++ b/SpaceDock/formatting.py
@@ -256,3 +256,10 @@ def referral_event_format(event):
         'host': event.host,
         'created': event.created.isoformat() if not event.created == None else None
     }
+
+def token_format(token):
+    return {
+        'id': token.id,
+        'content': token.token,
+        'ips': token['ips']
+    }

--- a/SpaceDock/objects.py
+++ b/SpaceDock/objects.py
@@ -8,6 +8,7 @@ from SpaceDock.thumbnail import create
 
 import bcrypt
 import binascii
+import hashlib
 import json
 import os.path
 import re
@@ -738,7 +739,7 @@ class Token(Base, MetaObject):
     token = Column(String(128))
 
     def __init__(self):
-        self.token = bcrypt.hashpw(binascii.b2a_hex(os.urandom(20)), bcrypt.gensalt()).decode('utf-8')
+        self.token = hashlib.md5(binascii.b2a_hex(os.urandom(20))).hexdigest()
 
     def __repr__(self):
         return '<Token %r>' % self.id

--- a/SpaceDock/objects.py
+++ b/SpaceDock/objects.py
@@ -736,7 +736,7 @@ class GameVersion(Base, MetaObject):
 class Token(Base, MetaObject):
     __tablename__ = 'token'
     id = Column(Integer, primary_key = True)
-    token = Column(String(128))
+    token = Column(String(32))
 
     def __init__(self):
         self.token = hashlib.md5(binascii.b2a_hex(os.urandom(20))).hexdigest()

--- a/SpaceDock/objects.py
+++ b/SpaceDock/objects.py
@@ -7,6 +7,7 @@ from SpaceDock.database import MetaObject, Base, db
 from SpaceDock.thumbnail import create
 
 import bcrypt
+import binascii
 import json
 import os.path
 import re
@@ -730,3 +731,15 @@ class GameVersion(Base, MetaObject):
 
     def __repr__(self):
         return '<Game Version %r>' % self.friendly_version
+
+class Token(Base, MetaObject):
+    __tablename__ = 'token'
+    id = Column(Integer, primary_key = True)
+    token = Column(String(128))
+
+    def __init__(self):
+        self.token = bcrypt.hashpw(binascii.b2a_hex(os.urandom(20)), bcrypt.gensalt()).decode('utf-8')
+        self['ips'] = list()
+
+    def __repr__(self):
+        return '<Token %r>' % self.id

--- a/SpaceDock/objects.py
+++ b/SpaceDock/objects.py
@@ -739,7 +739,6 @@ class Token(Base, MetaObject):
 
     def __init__(self):
         self.token = bcrypt.hashpw(binascii.b2a_hex(os.urandom(20)), bcrypt.gensalt()).decode('utf-8')
-        self['ips'] = list()
 
     def __repr__(self):
         return '<Token %r>' % self.id

--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -64,3 +64,11 @@ cache-expires=10
 # Enables threading in the flask app.
 # Stability: Unknown
 threaded=False
+
+# Access limiting
+# https://flask-limiter.readthedocs.io/en/stable/#ratelimit-string
+access-limit=100/second
+
+# Whether headers should be added, containing the current status 
+# of the access limiting
+limit-headers=False

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ SQLAlchemy
 psycopg2
 celery
 flask_cache
+flask_limiter

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ def new_user(name, password, email, admin):
         admin_role.add_param('packs-remove', 'gameshort', '.*')
         admin_role.add_param('publisher-edit', 'publid', '.*')
         admin_role.add_param('token-edit', 'tokenid', '.*')
+        admin_role.add_param('token-remove', 'tokenid', '.*')
         admin_role.add_param('user-edit', 'userid', '.*')
 
         db.add(admin_role)

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ def new_user(name, password, email, admin):
         admin_role = Role.query.filter(Role.name == 'admin').first()
         admin_role.add_abilities_re('.*')
         admin_role.add_abilities('mods-invite')
+        admin_role.add_abilities('view-users-full')
+        admin_role.add_abilities('no-limits')
 
         # Params
         admin_role.add_param('admin-impersonate', 'userid', '.*')
@@ -43,6 +45,7 @@ def new_user(name, password, email, admin):
         admin_role.add_param('packs-add', 'gameshort', '.*')
         admin_role.add_param('packs-remove', 'gameshort', '.*')
         admin_role.add_param('publisher-edit', 'publid', '.*')
+        admin_role.add_param('token-edit', 'tokenid', '.*')
         admin_role.add_param('user-edit', 'userid', '.*')
 
         db.add(admin_role)


### PR DESCRIPTION
This adds support for limiting the amount of requests one user can make withing a configurable amount of time.

At the same time, it adds support for access tokes, to work around this limitation (CKAN for example, or other apps that have to do lots of requests). Theese tokens are per-IP, and not associated to a specific user.
